### PR TITLE
Add support for Ubuntu 22.04 or greater

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@ import 'package:system_tray/system_tray.dart';
 ```bash
 sudo apt-get install appindicator3-0.1 libappindicator3-dev
 ```
+or
+
+```bash
+// For Ubuntu 22.04 or greater
+sudo apt-get install libayatana-appindicator3-dev
+```
 
 ## Example App
 
@@ -156,7 +162,7 @@ sudo apt-get install appindicator3-0.1 libappindicator3-dev
         <th>Linux</th>
     </tr>
     <tr>
-        <td>MenuItemLable</td>
+        <td>MenuItemLabel</td>
         <td></td>
         <td>✔️</td>
         <td>✔️</td>
@@ -204,9 +210,9 @@ Future<void> initSystemTray() async {
   // create context menu
   final Menu menu = Menu();
   await menu.buildFrom([
-    MenuItem(label: 'Show', onClicked: (menuItem) => appWindow.show()),
-    MenuItem(label: 'Hide', onClicked: (menuItem) => appWindow.hide()),
-    MenuItem(label: 'Exit', onClicked: (menuItem) => appWindow.close()),
+    MenuItemLabel(label: 'Show', onClicked: (menuItem) => appWindow.show()),
+    MenuItemLabel(label: 'Hide', onClicked: (menuItem) => appWindow.hide()),
+    MenuItemLabel(label: 'Exit', onClicked: (menuItem) => appWindow.close()),
   ]);
 
   // set context menu

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -7,7 +7,6 @@ project(${PROJECT_NAME} LANGUAGES CXX)
 set(PLUGIN_NAME "${PROJECT_NAME}_plugin")
 
 find_package(PkgConfig REQUIRED)
-pkg_check_modules(APPINDICATOR REQUIRED IMPORTED_TARGET appindicator3-0.1)
 
 add_library(${PLUGIN_NAME} SHARED
   "system_tray_plugin.cc"
@@ -17,6 +16,24 @@ add_library(${PLUGIN_NAME} SHARED
   "tray.cc"
   "errors.cc"
 )
+
+pkg_check_modules(APPINDICATOR IMPORTED_TARGET ayatana-appindicator3-0.1)
+if(APPINDICATOR_FOUND)
+  target_compile_definitions(${PLUGIN_NAME} PRIVATE HAVE_AYATANA)
+else()
+  pkg_check_modules(APPINDICATOR IMPORTED_TARGET appindicator3-0.1)
+endif()
+if(APPINDICATOR_FOUND)
+  target_link_libraries(${PLUGIN_NAME} PRIVATE PkgConfig::APPINDICATOR)
+else() 
+  message(
+    FATAL_ERROR
+    "\n"
+    "The `tray_manager` package requires ayatana-appindicator3-0.1 or appindicator3-0.1. See https://github.com/leanflutter/tray_manager#linux-requirements"
+  )
+endif()
+
+
 apply_standard_settings(${PLUGIN_NAME})
 set_target_properties(${PLUGIN_NAME} PROPERTIES
   CXX_VISIBILITY_PRESET hidden)

--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -29,7 +29,7 @@ else()
   message(
     FATAL_ERROR
     "\n"
-    "The `tray_manager` package requires ayatana-appindicator3-0.1 or appindicator3-0.1. See https://github.com/leanflutter/tray_manager#linux-requirements"
+    "The `system_tray` package requires ayatana-appindicator3-0.1 or appindicator3-0.1."
   )
 endif()
 

--- a/linux/tray.h
+++ b/linux/tray.h
@@ -3,7 +3,11 @@
 
 #include <flutter_linux/flutter_linux.h>
 #include <gtk/gtk.h>
+#ifdef HAVE_AYATANA
+#include <libayatana-appindicator/app-indicator.h>
+#else
 #include <libappindicator/app-indicator.h>
+#endif
 #include <memory>
 
 typedef AppIndicator* (*app_indicator_new_fun)(const gchar*,


### PR DESCRIPTION
Related issue:  #59 

@antler119  Added support for Ubuntu 22.04 or greater by adding alternative dependency on `ayatana-appindicator3-0.1` so now you can install it by running `sudo apt install libayatana-appindicator3-dev` without conflicting with other libraries.