### PR TITLE
Adds support template icons on macOS.

### DIFF
--- a/lib/src/tray.dart
+++ b/lib/src/tray.dart
@@ -21,6 +21,7 @@ const String _kTrayIdKey = "tray_id";
 const String _kTitleKey = "title";
 const String _kIconPathKey = "iconpath";
 const String _kToolTipKey = "tooltip";
+const String _kIsTemplateKey = "is_template";
 
 /// A callback provided to [SystemTray] to handle system tray click event.
 typedef SystemTrayEventCallback = void Function(String eventName);
@@ -41,6 +42,7 @@ class SystemTray {
     required String iconPath,
     String? title,
     String? toolTip,
+    bool isTemplate = false,
   }) async {
     bool value = await _platformChannel.invokeMethod(
       _kInitSystemTray,
@@ -49,6 +51,7 @@ class SystemTray {
         _kTitleKey: title,
         _kIconPathKey: await Utils.getIcon(iconPath),
         _kToolTipKey: toolTip,
+        _kIsTemplateKey: isTemplate,
       },
     );
     return value;
@@ -59,6 +62,7 @@ class SystemTray {
     String? title,
     String? iconPath,
     String? toolTip,
+    bool isTemplate = false,
   }) async {
     bool value = await _platformChannel.invokeMethod(
       _kSetSystemTrayInfo,
@@ -66,14 +70,15 @@ class SystemTray {
         _kTitleKey: title,
         _kIconPathKey: await Utils.getIcon(iconPath),
         _kToolTipKey: toolTip,
+        _kIsTemplateKey: isTemplate,
       },
     );
     return value;
   }
 
   /// (Windows\macOS\Linux) Sets the image associated with this tray icon
-  Future<void> setImage(String image) async {
-    await setSystemTrayInfo(iconPath: image);
+  Future<void> setImage(String image, {bool isTemplate = false}) async {
+    await setSystemTrayInfo(iconPath: image, isTemplate: isTemplate);
   }
 
   /// (Windows\macOS) Sets the hover text for this tray icon.

--- a/macos/Classes/Tray.swift
+++ b/macos/Classes/Tray.swift
@@ -14,6 +14,7 @@ private let kDefaultSizeHeight = 18
 private let kTitleKey = "title"
 private let kIconPathKey = "iconpath"
 private let kToolTipKey = "tooltip"
+private let kIsTemplateKey = "is_template"
 
 private let kSystemTrayEventClick = "click"
 private let kSystemTrayEventRightClick = "right-click"
@@ -83,6 +84,7 @@ class Tray: NSObject, NSMenuDelegate {
     let title = arguments[kTitleKey] as? String
     let base64Icon = arguments[kIconPathKey] as? String
     let toolTip = arguments[kToolTipKey] as? String
+    let isTemplate = arguments[kIsTemplateKey] as? Bool
 
     if statusItem != nil {
       result(false)
@@ -111,6 +113,7 @@ class Tray: NSObject, NSMenuDelegate {
       {
         let destSize = NSSize(width: kDefaultSizeWidth, height: kDefaultSizeHeight)
         itemImage.size = destSize
+        itemImage.isTemplate = isTemplate ?? false
         statusItem?.button?.image = itemImage
         statusItem?.button?.imagePosition = NSControl.ImagePosition.imageLeft
       }
@@ -124,6 +127,7 @@ class Tray: NSObject, NSMenuDelegate {
     let title = arguments[kTitleKey] as? String
     let base64Icon = arguments[kIconPathKey] as? String
     let toolTip = arguments[kToolTipKey] as? String
+    let isTemplate = arguments[kIsTemplateKey] as? Bool
 
     if let toolTip = toolTip {
       statusItem?.button?.toolTip = toolTip
@@ -139,6 +143,7 @@ class Tray: NSObject, NSMenuDelegate {
       {
         let destSize = NSSize(width: kDefaultSizeWidth, height: kDefaultSizeHeight)
         itemImage.size = destSize
+        itemImage.isTemplate = isTemplate ?? false
         statusItem?.button?.image = itemImage
         statusItem?.button?.imagePosition = NSControl.ImagePosition.imageLeft
       } else {


### PR DESCRIPTION
This PR adds support for specifying whether system tray icon is a [template](https://developer.apple.com/documentation/appkit/nsimage/1520017-template) icon on macOS. Template icons are icons that are tinted by macOS based on background.

Fixes #55 

#### Before

```dart
setImage(path);
```

#### After

```dart
setImage(path, isTemplate: true);
```